### PR TITLE
chore: Update version numbers and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **MidiPortal - Version 0.0.2**
+# **MidiPortal - Version 0.0.5**
 **Peer through the MidiPortal to observe all traffic on your system.**
 
 MidiPortal is a JUCE-based MIDI monitoring utility that allows you to visualize and analyze MIDI traffic in real-time. Designed as a lightweight tool, MidiPortal serves as the foundation for future enhancements, ultimately building toward the full iLumidi application.
@@ -31,6 +31,13 @@ MidiPortal is a JUCE-based MIDI monitoring utility that allows you to visualize 
 
 ### **0.0.1**:
 - Initial setup with JUCE framework and basic MIDI message handling.
+
+### **0.0.5**:
+- Added Rust-powered MIDI processing engine
+- Implemented comprehensive safety features
+- Added FFI interface for C++/Rust integration
+- Added note tracking and MPE support
+- Established protected branch structure
 
 ## **Requirements**
 ### **System Requirements**
@@ -263,3 +270,29 @@ Prerequisites:
 - JUCE
 - Rust toolchain
 - Ninja build system
+
+## New Features
+- Rust-powered MIDI processing engine with:
+  - Comprehensive safety features and error handling
+  - FFI interface for C++ integration
+  - MIDI message validation and processing
+  - Note tracking and expression monitoring
+  - MPE (MIDI Polyphonic Expression) support
+
+## Architecture
+- `rust/midi_engine/`: Core MIDI processing in Rust
+  - `lib.rs`: FFI interface and safety features
+  - `midi_processor.rs`: MIDI message handling
+  - `note_tracker.rs`: Note and expression tracking
+  - `mpe.rs`: MPE configuration and zones
+
+## Safety Features
+- Input validation and bounds checking
+- Memory safety with proper FFI
+- Error handling and reporting
+- Resource cleanup (Drop implementations)
+- Safe state management (Clone support)
+
+## Branch Structure
+- `cursor-main`: Stable, protected branch with working features
+- `cursor-development`: Active development branch

--- a/rust/midi_engine/Cargo.toml
+++ b/rust/midi_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midi_engine"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/rust/midi_engine/src/lib.rs
+++ b/rust/midi_engine/src/lib.rs
@@ -1,3 +1,5 @@
+//! MidiPortal Rust Engine v0.1.1
+//! Core MIDI processing with safety features
 use std::ffi::CString;
 use thiserror::Error;
 

--- a/rust/midi_engine/src/midi_processor.rs
+++ b/rust/midi_engine/src/midi_processor.rs
@@ -1,3 +1,5 @@
+//! MIDI message processing module v0.1.1
+//! Part of MidiPortal Rust Engine
 use crate::{MidiError, RustMidiStats};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 

--- a/rust/midi_engine/src/mpe.rs
+++ b/rust/midi_engine/src/mpe.rs
@@ -1,3 +1,6 @@
+//! MPE support module v0.1.1
+//! Part of MidiPortal Rust Engine
+
 use crate::MidiError;
 
 #[derive(Debug, Clone)]

--- a/rust/midi_engine/src/note_tracker.rs
+++ b/rust/midi_engine/src/note_tracker.rs
@@ -295,4 +295,7 @@ impl ExpressionStats {
             self.pitch_bend_activity * 100.0
         )
     }
-} 
+}
+
+//! Note tracking module v0.1.1
+//! Part of MidiPortal Rust Engine 


### PR DESCRIPTION
Updates version numbers and documentation:

MidiPortal:
- Bump to v0.0.5 (Rust integration milestone)
- Add new features section to README
- Add architecture documentation

Rust MIDI Engine:
- Bump to v0.1.1 (safety improvements)
- Add version comments to all modules
- Document safety features

This represents the milestone of having a working, safe Rust MIDI engine integrated with MidiPortal.